### PR TITLE
Add Form to Submit Monthly Service Metrics

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,3 @@
+Metrics/BlockLength:
+  Exclude:
+    - spec/**/*_spec.rb

--- a/app/assets/stylesheets/__base.scss
+++ b/app/assets/stylesheets/__base.scss
@@ -5,3 +5,13 @@
 main { display: block; }
 
 @import "homepage";
+
+fieldset {
+  border: 0;
+  padding: 0;
+}
+
+fieldset > h2 {
+  margin-top: 15px;
+  margin-bottom: 10px;
+}

--- a/app/controllers/monthly_service_metrics_controller.rb
+++ b/app/controllers/monthly_service_metrics_controller.rb
@@ -25,9 +25,8 @@ private
   end
 
   def load_metrics
-    @metrics = MonthlyServiceMetrics.new
-    @metrics.service = @service
-    @metrics.month = YearMonth.new(params[:year], params[:month])
+    month = YearMonth.new(params[:year], params[:month])
+    @metrics = MonthlyServiceMetrics.where(service: @service, month: month).first_or_initialize
 
     unless MonthlyServiceMetricsPublishToken.valid?(token: params[:publish_token], metrics: @metrics)
       render 'invalid_publish_token', status: :unauthorized

--- a/app/controllers/monthly_service_metrics_controller.rb
+++ b/app/controllers/monthly_service_metrics_controller.rb
@@ -1,16 +1,15 @@
 class MonthlyServiceMetricsController < ApplicationController
-  before_action :load_service, only: [:edit, :update]
-  before_action :load_metrics, only: [:edit, :update]
+  before_action :load_service, only: %i(edit update)
+  before_action :load_metrics, only: %i(edit update)
 
-  def edit
-  end
+  def edit; end
 
   def update
     @metrics.attributes = params.require(:metrics).permit(:online_transactions,
       :phone_transactions, :paper_transactions, :face_to_face_transactions,
       :other_transactions, :transactions_with_outcome, :transactions_with_intended_outcome,
       :calls_received, :calls_received_get_information, :calls_received_chase_progress,
-      :calls_received_challenge_decision, :calls_received_other).each {|_, value| value.gsub!(/\D/, '')}
+      :calls_received_challenge_decision, :calls_received_other).each { |_, value| value.gsub!(/\D/, '') }
 
     if @metrics.save
       render :success
@@ -19,7 +18,7 @@ class MonthlyServiceMetricsController < ApplicationController
     end
   end
 
-  private
+private
 
   def load_service
     @service ||= Service.find(params[:service_id])

--- a/app/controllers/monthly_service_metrics_controller.rb
+++ b/app/controllers/monthly_service_metrics_controller.rb
@@ -1,17 +1,11 @@
 class MonthlyServiceMetricsController < ApplicationController
   before_action :load_service, only: [:edit, :update]
+  before_action :load_metrics, only: [:edit, :update]
 
   def edit
-    @metrics = MonthlyServiceMetrics.new
-    @metrics.service = @service
-    @metrics.month = YearMonth.new(params[:year], params[:month])
   end
 
   def update
-    @metrics = MonthlyServiceMetrics.new
-    @metrics.service = @service
-    @metrics.month = YearMonth.new(params[:year], params[:month])
-
     @metrics.attributes = params.require(:metrics).permit(:online_transactions,
       :phone_transactions, :paper_transactions, :face_to_face_transactions,
       :other_transactions, :transactions_with_outcome, :transactions_with_intended_outcome,
@@ -29,5 +23,16 @@ class MonthlyServiceMetricsController < ApplicationController
 
   def load_service
     @service ||= Service.find(params[:service_id])
+  end
+
+  def load_metrics
+    @metrics = MonthlyServiceMetrics.new
+    @metrics.service = @service
+    @metrics.month = YearMonth.new(params[:year], params[:month])
+
+    unless MonthlyServiceMetricsPublishToken.valid?(token: params[:publish_token], metrics: @metrics)
+      render 'invalid_publish_token', status: :unauthorized
+      return
+    end
   end
 end

--- a/app/controllers/monthly_service_metrics_controller.rb
+++ b/app/controllers/monthly_service_metrics_controller.rb
@@ -8,8 +8,9 @@ class MonthlyServiceMetricsController < ApplicationController
     @metrics.attributes = params.require(:metrics).permit(:online_transactions,
       :phone_transactions, :paper_transactions, :face_to_face_transactions,
       :other_transactions, :transactions_with_outcome, :transactions_with_intended_outcome,
-      :calls_received, :calls_received_get_information, :calls_received_chase_progress,
-      :calls_received_challenge_decision, :calls_received_other).each { |_, value| value.gsub!(/\D/, '') }
+      :calls_received, :calls_received_perform_transaction, :calls_received_get_information,
+      :calls_received_chase_progress, :calls_received_challenge_decision,
+      :calls_received_other).each { |_, value| value.gsub!(/\D/, '') }
 
     if @metrics.save
       render :success

--- a/app/controllers/monthly_service_metrics_controller.rb
+++ b/app/controllers/monthly_service_metrics_controller.rb
@@ -1,0 +1,33 @@
+class MonthlyServiceMetricsController < ApplicationController
+  before_action :load_service, only: [:edit, :update]
+
+  def edit
+    @metrics = MonthlyServiceMetrics.new
+    @metrics.service = @service
+    @metrics.month = YearMonth.new(params[:year], params[:month])
+  end
+
+  def update
+    @metrics = MonthlyServiceMetrics.new
+    @metrics.service = @service
+    @metrics.month = YearMonth.new(params[:year], params[:month])
+
+    @metrics.attributes = params.require(:metrics).permit(:online_transactions,
+      :phone_transactions, :paper_transactions, :face_to_face_transactions,
+      :other_transactions, :transactions_with_outcome, :transactions_with_intended_outcome,
+      :calls_received, :calls_received_get_information, :calls_received_chase_progress,
+      :calls_received_challenge_decision, :calls_received_other).each {|_, value| value.gsub!(/\D/, '')}
+
+    if @metrics.save
+      render :success
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def load_service
+    @service ||= Service.find(params[:service_id])
+  end
+end

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -1,7 +1,7 @@
 module FormHelper
   class MonthlyServiceMetricsFormBuilder < ActionView::Helpers::FormBuilder
     def metric(name)
-      label = I18n.translate(name, scope: ['helpers', 'label', 'monthly_service_metrics'])
+      label = I18n.translate(name, scope: %w(helpers label monthly_service_metrics))
 
       @template.content_tag(:div, class: 'form-group') do
         label(name, label, class: 'form-label') + number_field(name, class: 'form-control form-control-1-4')

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -1,0 +1,11 @@
+module FormHelper
+  class MonthlyServiceMetricsFormBuilder < ActionView::Helpers::FormBuilder
+    def metric(name)
+      label = I18n.translate(name, scope: ['helpers', 'label', 'monthly_service_metrics'])
+
+      @template.content_tag(:div, class: 'form-group') do
+        label(name, label, class: 'form-label') + number_field(name, class: 'form-control form-control-1-4')
+      end
+    end
+  end
+end

--- a/app/models/monthly_service_metrics.rb
+++ b/app/models/monthly_service_metrics.rb
@@ -5,6 +5,8 @@ class MonthlyServiceMetrics < ApplicationRecord
 
   attribute :month, YearMonth::Serializer.new
 
+  validates_uniqueness_of :month, scope: :service, strict: true
+
   def publish_date
     if month
       month.date + 2.months

--- a/app/models/monthly_service_metrics.rb
+++ b/app/models/monthly_service_metrics.rb
@@ -1,0 +1,19 @@
+class MonthlyServiceMetrics < ApplicationRecord
+  self.table_name = 'monthly_service_metrics'
+
+  belongs_to :service
+
+  attribute :month, YearMonth::Serializer.new
+
+  def publish_date
+    if month
+      month.date + 2.months
+    end
+  end
+
+  def next_metrics_due_date
+    if month
+      month.date + 1.month
+    end
+  end
+end

--- a/app/models/monthly_service_metrics_publish_token.rb
+++ b/app/models/monthly_service_metrics_publish_token.rb
@@ -1,0 +1,22 @@
+class MonthlyServiceMetricsPublishToken
+  def self.generate(service:, month:)
+    verifier = ActiveSupport::MessageVerifier.new(service.publish_token)
+    verifier.generate({
+      year: month.year,
+      month: month.month
+    })
+  end
+
+  def self.valid?(token:, metrics:)
+    raise ArgumentError, 'MonthlyServiceMetrics#month must be set' if metrics.month.nil?
+    raise ArgumentError, 'MonthlyServiceMetrics#service must be set' if metrics.service.nil?
+
+    service = metrics.service
+    verifier = ActiveSupport::MessageVerifier.new(service.publish_token)
+    payload = verifier.verify(token)
+
+    payload.fetch(:year) == metrics.month.year && payload.fetch(:month) == metrics.month.month
+  rescue ActiveSupport::MessageVerifier::InvalidSignature
+    false
+  end
+end

--- a/app/models/monthly_service_metrics_publish_token.rb
+++ b/app/models/monthly_service_metrics_publish_token.rb
@@ -1,10 +1,7 @@
 class MonthlyServiceMetricsPublishToken
   def self.generate(service:, month:)
     verifier = ActiveSupport::MessageVerifier.new(service.publish_token)
-    verifier.generate({
-      year: month.year,
-      month: month.month
-    })
+    verifier.generate(year: month.year, month: month.month)
   end
 
   def self.valid?(token:, metrics:)

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -1,3 +1,7 @@
 class Service < ApplicationRecord
   validates_presence_of :name
+
+  before_create do
+    self.publish_token ||= SecureRandom.hex(64)
+  end
 end

--- a/app/models/year_month.rb
+++ b/app/models/year_month.rb
@@ -1,0 +1,44 @@
+class YearMonth
+  class Serializer < ActiveRecord::Type::Value
+    def type
+      :year_month
+    end
+
+    def cast(value)
+      value
+    end
+
+    def serialize(value)
+      value ? value.date : nil
+    end
+
+    def deserialize(value)
+      case value
+      when Date
+        YearMonth.new(value.year, value.month)
+      when String
+        date = Date.parse(value)
+        YearMonth.new(date.year, date.month)
+      else
+        nil
+      end
+    end
+  end
+
+  def initialize(year, month)
+    @year = year.to_i
+    @month = month.to_i
+    @date = Date.new(@year, @month)
+  end
+
+  attr_reader :year, :month, :date
+
+  def ==(other)
+    year == other.year && month == other.month
+  end
+
+  def to_formatted_s
+    end_date = date.end_of_month
+    "#{date.to_formatted_s(:day_excluding_leading_zero)} to #{end_date.to_formatted_s(:long_day_month_year)}"
+  end
+end

--- a/app/models/year_month.rb
+++ b/app/models/year_month.rb
@@ -19,8 +19,6 @@ class YearMonth
       when String
         date = Date.parse(value)
         YearMonth.new(date.year, date.month)
-      else
-        nil
       end
     end
   end

--- a/app/views/monthly_service_metrics/edit.html.erb
+++ b/app/views/monthly_service_metrics/edit.html.erb
@@ -1,0 +1,56 @@
+<div class="grid-row">
+
+  <div class="column-two-thirds">
+
+    <h1 class="heading-large">
+      Provide data for the period <%= @metrics.month.to_formatted_s %>
+    </h1>
+
+    <p>
+     Here's a <a href="../service-manual">reminder of what you need to provide</a>. Your data will be published on <%= @metrics.publish_date.to_formatted_s(:long_day_month_year) %>.
+    </p>
+
+    <%= form_for(@metrics, as: :metrics, builder: FormHelper::MonthlyServiceMetricsFormBuilder, url: '', method: :patch) do |f| %>
+      <fieldset>
+        <h2 class="bold-medium">Number of transactions received, split by channel</h2>
+
+        <%= f.metric :online_transactions %>
+        <%= f.metric :phone_transactions %>
+        <%= f.metric :paper_transactions %>
+        <%= f.metric :face_to_face_transactions %>
+        <%= f.metric :other_transactions %>
+      </fieldset>
+
+      <fieldset>
+        <h2 class="bold-medium">Number of transactions ending in an outcome</h2>
+
+        <%= f.metric :transactions_with_outcome %>
+      </fieldset>
+
+      <fieldset>
+        <h2 class="bold-medium">Number of transactions ending in the user’s intended outcome</h2>
+
+        <%= f.metric :transactions_with_intended_outcome %>
+      </fieldset>
+
+      <fieldset>
+        <h2 class="bold-medium">Total number of phone calls received</h2>
+
+        <%= f.metric :calls_received %>
+      </fieldset>
+
+      <fieldset>
+        <h2 class="bold-medium">Number of phone calls received, split by reasons for calling</h2>
+
+        <%= f.metric :calls_received_get_information %>
+        <%= f.metric :calls_received_chase_progress %>
+        <%= f.metric :calls_received_challenge_decision %>
+        <%= f.metric :calls_received_other %>
+      </fieldset>
+
+      <p>
+        <%= f.submit 'Submit', class: 'button' %>
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/monthly_service_metrics/edit.html.erb
+++ b/app/views/monthly_service_metrics/edit.html.erb
@@ -1,56 +1,58 @@
-<div class="grid-row">
+<main id="content" role="main" class="container">
+  <div class="grid-row">
 
-  <div class="column-two-thirds">
+    <div class="column-two-thirds">
 
-    <h1 class="heading-large">
-      Provide data for the period <%= @metrics.month.to_formatted_s %>
-    </h1>
-
-    <p>
-     Here's a <a href="../service-manual">reminder of what you need to provide</a>. Your data will be published on <%= @metrics.publish_date.to_formatted_s(:long_day_month_year) %>.
-    </p>
-
-    <%= form_for(@metrics, as: :metrics, url: service_metrics_path(publish_token: params[:publish_token]), method: :patch, builder: FormHelper::MonthlyServiceMetricsFormBuilder) do |f| %>
-      <fieldset>
-        <h2 class="bold-medium">Number of transactions received, split by channel</h2>
-
-        <%= f.metric :online_transactions %>
-        <%= f.metric :phone_transactions %>
-        <%= f.metric :paper_transactions %>
-        <%= f.metric :face_to_face_transactions %>
-        <%= f.metric :other_transactions %>
-      </fieldset>
-
-      <fieldset>
-        <h2 class="bold-medium">Number of transactions ending in an outcome</h2>
-
-        <%= f.metric :transactions_with_outcome %>
-      </fieldset>
-
-      <fieldset>
-        <h2 class="bold-medium">Number of transactions ending in the user’s intended outcome</h2>
-
-        <%= f.metric :transactions_with_intended_outcome %>
-      </fieldset>
-
-      <fieldset>
-        <h2 class="bold-medium">Total number of phone calls received</h2>
-
-        <%= f.metric :calls_received %>
-      </fieldset>
-
-      <fieldset>
-        <h2 class="bold-medium">Number of phone calls received, split by reasons for calling</h2>
-
-        <%= f.metric :calls_received_get_information %>
-        <%= f.metric :calls_received_chase_progress %>
-        <%= f.metric :calls_received_challenge_decision %>
-        <%= f.metric :calls_received_other %>
-      </fieldset>
+      <h1 class="heading-large">
+        Provide data for the period <%= @metrics.month.to_formatted_s %>
+      </h1>
 
       <p>
-        <%= f.submit 'Submit', class: 'button' %>
+       Here's a <a href="../service-manual">reminder of what you need to provide</a>. Your data will be published on <%= @metrics.publish_date.to_formatted_s(:long_day_month_year) %>.
       </p>
-    <% end %>
+
+      <%= form_for(@metrics, as: :metrics, url: service_metrics_path(publish_token: params[:publish_token]), method: :patch, builder: FormHelper::MonthlyServiceMetricsFormBuilder) do |f| %>
+        <fieldset>
+          <h2 class="bold-medium">Number of transactions received, split by channel</h2>
+
+          <%= f.metric :online_transactions %>
+          <%= f.metric :phone_transactions %>
+          <%= f.metric :paper_transactions %>
+          <%= f.metric :face_to_face_transactions %>
+          <%= f.metric :other_transactions %>
+        </fieldset>
+
+        <fieldset>
+          <h2 class="bold-medium">Number of transactions ending in an outcome</h2>
+
+          <%= f.metric :transactions_with_outcome %>
+        </fieldset>
+
+        <fieldset>
+          <h2 class="bold-medium">Number of transactions ending in the user’s intended outcome</h2>
+
+          <%= f.metric :transactions_with_intended_outcome %>
+        </fieldset>
+
+        <fieldset>
+          <h2 class="bold-medium">Total number of phone calls received</h2>
+
+          <%= f.metric :calls_received %>
+        </fieldset>
+
+        <fieldset>
+          <h2 class="bold-medium">Number of phone calls received, split by reasons for calling</h2>
+
+          <%= f.metric :calls_received_get_information %>
+          <%= f.metric :calls_received_chase_progress %>
+          <%= f.metric :calls_received_challenge_decision %>
+          <%= f.metric :calls_received_other %>
+        </fieldset>
+
+        <p>
+          <%= f.submit 'Submit', class: 'button' %>
+        </p>
+      <% end %>
+    </div>
   </div>
-</div>
+</main>

--- a/app/views/monthly_service_metrics/edit.html.erb
+++ b/app/views/monthly_service_metrics/edit.html.erb
@@ -10,7 +10,7 @@
      Here's a <a href="../service-manual">reminder of what you need to provide</a>. Your data will be published on <%= @metrics.publish_date.to_formatted_s(:long_day_month_year) %>.
     </p>
 
-    <%= form_for(@metrics, as: :metrics, builder: FormHelper::MonthlyServiceMetricsFormBuilder, url: '', method: :patch) do |f| %>
+    <%= form_for(@metrics, as: :metrics, url: service_metrics_path, method: :patch, builder: FormHelper::MonthlyServiceMetricsFormBuilder) do |f| %>
       <fieldset>
         <h2 class="bold-medium">Number of transactions received, split by channel</h2>
 

--- a/app/views/monthly_service_metrics/edit.html.erb
+++ b/app/views/monthly_service_metrics/edit.html.erb
@@ -10,7 +10,7 @@
      Here's a <a href="../service-manual">reminder of what you need to provide</a>. Your data will be published on <%= @metrics.publish_date.to_formatted_s(:long_day_month_year) %>.
     </p>
 
-    <%= form_for(@metrics, as: :metrics, url: service_metrics_path, method: :patch, builder: FormHelper::MonthlyServiceMetricsFormBuilder) do |f| %>
+    <%= form_for(@metrics, as: :metrics, url: service_metrics_path(publish_token: params[:publish_token]), method: :patch, builder: FormHelper::MonthlyServiceMetricsFormBuilder) do |f| %>
       <fieldset>
         <h2 class="bold-medium">Number of transactions received, split by channel</h2>
 

--- a/app/views/monthly_service_metrics/edit.html.erb
+++ b/app/views/monthly_service_metrics/edit.html.erb
@@ -43,6 +43,7 @@
         <fieldset>
           <h2 class="bold-medium">Number of phone calls received, split by reasons for calling</h2>
 
+          <%= f.metric :calls_received_perform_transaction %>
           <%= f.metric :calls_received_get_information %>
           <%= f.metric :calls_received_chase_progress %>
           <%= f.metric :calls_received_challenge_decision %>

--- a/app/views/monthly_service_metrics/invalid_publish_token.html.erb
+++ b/app/views/monthly_service_metrics/invalid_publish_token.html.erb
@@ -1,0 +1,7 @@
+<div class="column-two-thirds">
+  <h1 class="heading-large">
+    Invalid Link
+  </h1>
+  
+  <p>This link is invalid.</p>
+</div>

--- a/app/views/monthly_service_metrics/invalid_publish_token.html.erb
+++ b/app/views/monthly_service_metrics/invalid_publish_token.html.erb
@@ -1,7 +1,9 @@
-<div class="column-two-thirds">
-  <h1 class="heading-large">
-    Invalid Link
-  </h1>
+<main id="content" role="main" class="container">
+  <div class="column-two-thirds">
+    <h1 class="heading-large">
+      Invalid Link
+    </h1>
   
-  <p>This link is invalid.</p>
-</div>
+    <p>This link is invalid.</p>
+  </div>
+</main>

--- a/app/views/monthly_service_metrics/success.html.erb
+++ b/app/views/monthly_service_metrics/success.html.erb
@@ -1,0 +1,10 @@
+<div class="column-two-thirds">
+  <h1 class="heading-large">
+    Upload successful
+  </h1>
+
+  <p>Thank you for providing your monthly data. It will be published on <%= @metrics.publish_date.to_formatted_s(:long_day_month_year) %>.</p>
+
+  <p>You will next be asked to provide data on the <%= @metrics.next_metrics_due_date.to_formatted_s(:long_day_month) %>.</p>
+
+</div>

--- a/app/views/monthly_service_metrics/success.html.erb
+++ b/app/views/monthly_service_metrics/success.html.erb
@@ -1,10 +1,12 @@
-<div class="column-two-thirds">
-  <h1 class="heading-large">
-    Upload successful
-  </h1>
+<main id="content" role="main" class="container">
+  <div class="column-two-thirds">
+    <h1 class="heading-large">
+      Upload successful
+    </h1>
 
-  <p>Thank you for providing your monthly data. It will be published on <%= @metrics.publish_date.to_formatted_s(:long_day_month_year) %>.</p>
+    <p>Thank you for providing your monthly data. It will be published on <%= @metrics.publish_date.to_formatted_s(:long_day_month_year) %>.</p>
 
-  <p>You will next be asked to provide data on the <%= @metrics.next_metrics_due_date.to_formatted_s(:long_day_month) %>.</p>
+    <p>You will next be asked to provide data on <%= @metrics.next_metrics_due_date.to_formatted_s(:long_day_month) %>.</p>
 
-</div>
+  </div>
+</main>

--- a/bin/generate-publish-tokens
+++ b/bin/generate-publish-tokens
@@ -1,0 +1,38 @@
+#!./rails runner
+#
+# Usage: ./generate-publish-tokens <year> <month>
+#
+# Generates a CSV file, with a row per service, containing a publish token
+# (and path) for that month's service metrics submission.
+
+require 'csv'
+
+include Rails.application.routes.url_helpers
+
+year = ARGV[0]
+month = ARGV[1]
+if year.nil? || month.nil?
+  $stderr.puts "invalid arguments: year='%s' month='%s'" % [year, month]
+  exit 1
+end
+
+begin
+  month = YearMonth.new(ARGV[0], ARGV[1])
+rescue
+  $stderr.puts "invalid date: year='%s' month='%s'" % [year, month]
+  exit 1
+end
+
+csv = CSV.new($stdout)
+csv << ['Service', 'Year', 'Month', 'Publish Token', 'Publish Metrics URL']
+
+services = Service.all
+
+services.each do |service|
+  token = MonthlyServiceMetricsPublishToken.generate(service: service, month: month)
+  path = service_metrics_path(service_id: service.to_param, year: month.year, month: month.month.to_s.rjust(2, '0'), publish_token: token)
+  csv << [service.name, month.year, month.month, token, path]
+end
+
+csv.close
+

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,0 +1,3 @@
+Date::DATE_FORMATS[:day_excluding_leading_zero] = '%-d'
+Date::DATE_FORMATS[:long_day_month] = '%-d %B'
+Date::DATE_FORMATS[:long_day_month_year] = '%-d %B %Y'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,6 +10,7 @@ en:
         transactions_with_outcome: Transactions ending in an outcome
         transactions_with_intended_outcome: Transactions ending in the user's intended outcome
         calls_received: Calls received
+        calls_received_perform_transaction: to perform a transaction
         calls_received_get_information: to get information
         calls_received_chase_progress: to chase progress
         calls_received_challenge_decision: to challenge a decision

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,19 @@
 en:
   helpers:
     label:
+      monthly_service_metrics:
+        online_transactions: Online
+        phone_transactions: Phone
+        paper_transactions: Paper
+        face_to_face_transactions: Face-to-face
+        other_transactions: Other
+        transactions_with_outcome: Transactions ending in an outcome
+        transactions_with_intended_outcome: Transactions ending in the user's intended outcome
+        calls_received: Calls received
+        calls_received_get_information: to get information
+        calls_received_chase_progress: to chase progress
+        calls_received_challenge_decision: to challenge a decision
+        calls_received_other: Other
       service:
         start_page_url: Start page URL
         paper_form_url: Paper form URL

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,13 @@ Rails.application.routes.draw do
     root to: "services#index"
   end
 
+  resources :services, only: [] do
+    constraints year: /\d{4}/, month: /\d{2}/ do
+      get 'metrics/:year/:month', to: 'monthly_service_metrics#edit', as: :metrics
+      patch 'metrics/:year/:month', to: 'monthly_service_metrics#update'
+    end
+  end
+
   devise_for :users
   root 'pages#homepage'
-
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,8 +8,8 @@ Rails.application.routes.draw do
 
   resources :services, only: [] do
     constraints year: /\d{4}/, month: /\d{2}/ do
-      get 'metrics/:year/:month', to: 'monthly_service_metrics#edit', as: :metrics
-      patch 'metrics/:year/:month', to: 'monthly_service_metrics#update'
+      get 'metrics/:year/:month(/:publish_token)', to: 'monthly_service_metrics#edit', as: :metrics
+      patch 'metrics/:year/:month(/:publish_token)', to: 'monthly_service_metrics#update'
     end
   end
 

--- a/db/migrate/20170925105259_create_monthly_service_metrics.rb
+++ b/db/migrate/20170925105259_create_monthly_service_metrics.rb
@@ -1,0 +1,22 @@
+class CreateMonthlyServiceMetrics < ActiveRecord::Migration[5.1]
+  def change
+    create_table :monthly_service_metrics do |t|
+      t.references :service, null: false
+      t.date :month, null: false
+      t.integer :online_transactions
+      t.integer :phone_transactions
+      t.integer :paper_transactions
+      t.integer :face_to_face_transactions
+      t.integer :other_transactions
+      t.integer :transactions_with_outcome
+      t.integer :transactions_with_intended_outcome
+      t.integer :calls_received
+      t.integer :calls_received_get_information
+      t.integer :calls_received_chase_progress
+      t.integer :calls_received_challenge_decision
+      t.integer :calls_received_other
+    end
+
+    add_foreign_key :monthly_service_metrics, :services
+  end
+end

--- a/db/migrate/20170926142130_add_publish_token_to_services.rb
+++ b/db/migrate/20170926142130_add_publish_token_to_services.rb
@@ -1,0 +1,6 @@
+class AddPublishTokenToServices < ActiveRecord::Migration[5.1]
+  def change
+    add_column :services, :publish_token, :string
+    add_index :services, :publish_token, unique: true
+  end
+end

--- a/db/migrate/20170927103203_add_unique_index_for_service_month.rb
+++ b/db/migrate/20170927103203_add_unique_index_for_service_month.rb
@@ -1,0 +1,9 @@
+class AddUniqueIndexForServiceMonth < ActiveRecord::Migration[5.1]
+  def up
+    execute "CREATE UNIQUE INDEX unique_monthly_service_metrics ON monthly_service_metrics (service_id, DATE_TRUNC('month', month::timestamp without time zone))"
+  end
+
+  def down
+    execute 'DROP INDEX unique_monthly_service_metrics'
+  end
+end

--- a/db/migrate/20170928100829_add_calls_received_perform_transaction_to_monthly_service_metrics.rb
+++ b/db/migrate/20170928100829_add_calls_received_perform_transaction_to_monthly_service_metrics.rb
@@ -1,0 +1,5 @@
+class AddCallsReceivedPerformTransactionToMonthlyServiceMetrics < ActiveRecord::Migration[5.1]
+  def change
+    add_column :monthly_service_metrics, :calls_received_perform_transaction, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170925105259) do
+ActiveRecord::Schema.define(version: 20170926142130) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,6 +44,8 @@ ActiveRecord::Schema.define(version: 20170925105259) do
     t.string "paper_form_url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "publish_token"
+    t.index ["publish_token"], name: "index_services_on_publish_token", unique: true
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170926142130) do
+ActiveRecord::Schema.define(version: 20170927103203) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 20170926142130) do
     t.integer "calls_received_chase_progress"
     t.integer "calls_received_challenge_decision"
     t.integer "calls_received_other"
+    t.index "service_id, date_trunc('month'::text, (month)::timestamp without time zone)", name: "unique_monthly_service_metrics", unique: true
     t.index ["service_id"], name: "index_monthly_service_metrics_on_service_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170927103203) do
+ActiveRecord::Schema.define(version: 20170928100829) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 20170927103203) do
     t.integer "calls_received_chase_progress"
     t.integer "calls_received_challenge_decision"
     t.integer "calls_received_other"
+    t.integer "calls_received_perform_transaction"
     t.index "service_id, date_trunc('month'::text, (month)::timestamp without time zone)", name: "unique_monthly_service_metrics", unique: true
     t.index ["service_id"], name: "index_monthly_service_metrics_on_service_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,28 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170913094522) do
+ActiveRecord::Schema.define(version: 20170925105259) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "monthly_service_metrics", force: :cascade do |t|
+    t.bigint "service_id", null: false
+    t.date "month", null: false
+    t.integer "online_transactions"
+    t.integer "phone_transactions"
+    t.integer "paper_transactions"
+    t.integer "face_to_face_transactions"
+    t.integer "other_transactions"
+    t.integer "transactions_with_outcome"
+    t.integer "transactions_with_intended_outcome"
+    t.integer "calls_received"
+    t.integer "calls_received_get_information"
+    t.integer "calls_received_chase_progress"
+    t.integer "calls_received_challenge_decision"
+    t.integer "calls_received_other"
+    t.index ["service_id"], name: "index_monthly_service_metrics_on_service_id"
+  end
 
   create_table "services", force: :cascade do |t|
     t.string "name", null: false
@@ -48,4 +66,5 @@ ActiveRecord::Schema.define(version: 20170913094522) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "monthly_service_metrics", "services"
 end

--- a/spec/controllers/monthly_service_metrics_controller_spec.rb
+++ b/spec/controllers/monthly_service_metrics_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe MonthlyServiceMetricsController, type: :controller do
     let(:service) { instance_double(Service, id: '01') }
 
     before do
-      allow(MonthlyServiceMetrics).to receive(:new) { metrics }
+      allow(MonthlyServiceMetrics).to receive_message_chain(:where, :first_or_initialize) { metrics }
       allow(Service).to receive(:find).with(service.id) { service }
     end
 
@@ -54,7 +54,7 @@ RSpec.describe MonthlyServiceMetricsController, type: :controller do
     let(:service) { instance_double(Service, id: '01') }
 
     before do
-      allow(MonthlyServiceMetrics).to receive(:new) { metrics }
+      allow(MonthlyServiceMetrics).to receive_message_chain(:where, :first_or_initialize) { metrics }
       allow(Service).to receive(:find).with(service.id) { service }
     end
 

--- a/spec/controllers/monthly_service_metrics_controller_spec.rb
+++ b/spec/controllers/monthly_service_metrics_controller_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe MonthlyServiceMetricsController, type: :controller do
-
   shared_examples_for 'validating publish token' do
     context 'with an invalid publish token' do
       before do
@@ -50,7 +49,7 @@ RSpec.describe MonthlyServiceMetricsController, type: :controller do
     end
 
     let(:publish_token) { 'PuBlIsHtOkEn' }
-    let(:metrics_params) { {'online_transactions' => '1000'} }
+    let(:metrics_params) { { 'online_transactions' => '1000' } }
     let(:metrics) { instance_double(MonthlyServiceMetrics, :service= => nil, :month= => nil, :attributes= => nil) }
     let(:service) { instance_double(Service, id: '01') }
 
@@ -85,5 +84,4 @@ RSpec.describe MonthlyServiceMetricsController, type: :controller do
       end
     end
   end
-  
 end

--- a/spec/controllers/monthly_service_metrics_controller_spec.rb
+++ b/spec/controllers/monthly_service_metrics_controller_spec.rb
@@ -1,0 +1,89 @@
+require 'rails_helper'
+
+RSpec.describe MonthlyServiceMetricsController, type: :controller do
+
+  shared_examples_for 'validating publish token' do
+    context 'with an invalid publish token' do
+      before do
+        allow(MonthlyServiceMetricsPublishToken).to receive(:valid?).with(token: publish_token, metrics: metrics) { false }
+      end
+
+      it 'renders invalid template' do
+        dispatch
+        expect(response.status).to eq(401)
+        expect(response).to render_template('monthly_service_metrics/invalid_publish_token')
+      end
+    end
+  end
+
+  describe 'GET edit' do
+    def dispatch
+      get :edit, params: { service_id: service.id, year: '2017', month: '06', publish_token: publish_token }
+    end
+
+    let(:publish_token) { 'PuBlIsHtOkEn' }
+    let(:metrics) { instance_double(MonthlyServiceMetrics, :service= => nil, :month= => nil) }
+    let(:service) { instance_double(Service, id: '01') }
+
+    before do
+      allow(MonthlyServiceMetrics).to receive(:new) { metrics }
+      allow(Service).to receive(:find).with(service.id) { service }
+    end
+
+    it_behaves_like 'validating publish token'
+
+    context 'with a valid publish token' do
+      before do
+        allow(MonthlyServiceMetricsPublishToken).to receive(:valid?).with(token: publish_token, metrics: metrics) { true }
+      end
+
+      it 'renders edit template' do
+        dispatch
+        expect(response).to render_template('monthly_service_metrics/edit')
+      end
+    end
+  end
+
+  describe 'PATCH update' do
+    def dispatch
+      patch :update, params: { service_id: service.id, year: '2017', month: '06', publish_token: publish_token, metrics: metrics_params }
+    end
+
+    let(:publish_token) { 'PuBlIsHtOkEn' }
+    let(:metrics_params) { {'online_transactions' => '1000'} }
+    let(:metrics) { instance_double(MonthlyServiceMetrics, :service= => nil, :month= => nil, :attributes= => nil) }
+    let(:service) { instance_double(Service, id: '01') }
+
+    before do
+      allow(MonthlyServiceMetrics).to receive(:new) { metrics }
+      allow(Service).to receive(:find).with(service.id) { service }
+    end
+
+    it_behaves_like 'validating publish token'
+
+    context 'with valid metrics' do
+      before do
+        allow(MonthlyServiceMetricsPublishToken).to receive(:valid?).with(token: publish_token, metrics: metrics) { true }
+        allow(metrics).to receive(:save) { true }
+      end
+
+      it 'renders success template' do
+        dispatch
+        expect(response).to render_template('monthly_service_metrics/success')
+      end
+    end
+
+    context 'with invalid metrics' do
+      before do
+        allow(MonthlyServiceMetricsPublishToken).to receive(:valid?).with(token: publish_token, metrics: metrics) { true }
+        allow(metrics).to receive(:save) { false }
+      end
+
+      it 'renders edit template' do
+        dispatch
+        expect(response).to render_template('monthly_service_metrics/edit')
+      end
+    end
+  end
+  
+end

--- a/spec/factories/monthly_service_metrics.rb
+++ b/spec/factories/monthly_service_metrics.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :monthly_service_metrics do
+    service
+  end
+end

--- a/spec/features/submitting_monthly_service_metrics_spec.rb
+++ b/spec/features/submitting_monthly_service_metrics_spec.rb
@@ -57,7 +57,7 @@ RSpec.feature 'submitting monthly service metrics' do
 
     expect(page).to have_text('Upload successful')
     expect(page).to have_text('Thank you for providing your monthly data. It will be published on 1 November 2017.')
-    expect(page).to have_text('You will next be asked to provide data on the 1 October.')
+    expect(page).to have_text('You will next be asked to provide data on 1 October.')
   end
 
   private

--- a/spec/features/submitting_monthly_service_metrics_spec.rb
+++ b/spec/features/submitting_monthly_service_metrics_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.feature 'submitting monthly service metrics' do
-
   specify 'submitting metrics' do
     service = FactoryGirl.create(:service)
     publish_token = MonthlyServiceMetricsPublishToken.generate(service: service, month: YearMonth.new(2017, 9))

--- a/spec/features/submitting_monthly_service_metrics_spec.rb
+++ b/spec/features/submitting_monthly_service_metrics_spec.rb
@@ -1,0 +1,79 @@
+require 'rails_helper'
+
+RSpec.feature 'submitting monthly service metrics' do
+
+  specify 'submitting metrics' do
+    service = FactoryGirl.create(:service)
+
+    visit service_metrics_path(service_id: service, year: '2017', month: '09')
+
+    expect(page).to have_text('Provide data for the period 1 to 30 September 2017')
+    expect(page).to have_text('Your data will be published on 1 November 2017.')
+
+    within_fieldset('Number of transactions received, split by channel') do
+      fill_in 'Online', with: '18,000'
+      fill_in 'Phone', with: '17,000'
+      fill_in 'Paper', with: '16,000'
+      fill_in 'Face-to-face', with: '15,000'
+      fill_in 'Other', with: '14,000'
+    end
+
+    within_fieldset('Number of transactions ending in an outcome') do
+      fill_in 'Transactions ending in an outcome', with: '13,000'
+    end
+
+    within_fieldset('Number of transactions ending in the user’s intended outcome') do
+      fill_in "Transactions ending in the user's intended outcome", with: '12,000'
+    end
+
+    within_fieldset('Total number of phone calls received') do
+      fill_in 'Calls received', with: '11,000'
+    end
+
+    within_fieldset('Number of phone calls received, split by reasons for calling') do
+      fill_in 'to get information', with: '10,000'
+      fill_in 'to chase progress', with: '9,000'
+      fill_in 'to challenge a decision', with: '8,000'
+      fill_in 'Other', with: '7,000'
+    end
+
+    click_button 'Submit'
+
+    metrics = MonthlyServiceMetrics.last
+    expect(metrics.service).to eq(service)
+    expect(metrics.month).to eq(YearMonth.new(2017, 9))
+    expect(metrics.online_transactions).to eq(18000)
+    expect(metrics.phone_transactions).to eq(17000)
+    expect(metrics.paper_transactions).to eq(16000)
+    expect(metrics.face_to_face_transactions).to eq(15000)
+    expect(metrics.other_transactions).to eq(14000)
+    expect(metrics.transactions_with_outcome).to eq(13000)
+    expect(metrics.transactions_with_intended_outcome).to eq(12000)
+    expect(metrics.calls_received).to eq(11000)
+    expect(metrics.calls_received_get_information).to eq(10000)
+    expect(metrics.calls_received_chase_progress).to eq(9000)
+    expect(metrics.calls_received_challenge_decision).to eq(8000)
+    expect(metrics.calls_received_other).to eq(7000)
+
+    expect(page).to have_text('Upload successful')
+    expect(page).to have_text('Thank you for providing your monthly data. It will be published on 1 November 2017.')
+    expect(page).to have_text('You will next be asked to provide data on the 1 October.')
+  end
+
+  private
+
+  def within_fieldset(text, &block)
+    fieldsets = all('fieldset').select do |fieldset|
+      fieldset.first('h2', text: text)
+    end
+
+    case fieldsets.size
+    when 1
+      within(fieldsets.first, &block)
+    when 0
+      raise 'No fieldset found, with heading "%s"' % [text]
+    else
+      raise 'Ambiguous fieldsets, %d fieldsets found with heading "%s"' % [fieldsets.size, text]
+    end
+  end
+end

--- a/spec/features/submitting_monthly_service_metrics_spec.rb
+++ b/spec/features/submitting_monthly_service_metrics_spec.rb
@@ -4,8 +4,9 @@ RSpec.feature 'submitting monthly service metrics' do
 
   specify 'submitting metrics' do
     service = FactoryGirl.create(:service)
+    publish_token = MonthlyServiceMetricsPublishToken.generate(service: service, month: YearMonth.new(2017, 9))
 
-    visit service_metrics_path(service_id: service, year: '2017', month: '09')
+    visit service_metrics_path(service_id: service, year: '2017', month: '09', publish_token: publish_token)
 
     expect(page).to have_text('Provide data for the period 1 to 30 September 2017')
     expect(page).to have_text('Your data will be published on 1 November 2017.')

--- a/spec/features/submitting_monthly_service_metrics_spec.rb
+++ b/spec/features/submitting_monthly_service_metrics_spec.rb
@@ -31,6 +31,7 @@ RSpec.feature 'submitting monthly service metrics' do
     end
 
     within_fieldset('Number of phone calls received, split by reasons for calling') do
+      fill_in 'to perform a transaction', with: '6,000'
       fill_in 'to get information', with: '10,000'
       fill_in 'to chase progress', with: '9,000'
       fill_in 'to challenge a decision', with: '8,000'
@@ -50,6 +51,7 @@ RSpec.feature 'submitting monthly service metrics' do
     expect(metrics.transactions_with_outcome).to eq(13000)
     expect(metrics.transactions_with_intended_outcome).to eq(12000)
     expect(metrics.calls_received).to eq(11000)
+    expect(metrics.calls_received_perform_transaction).to eq(6000)
     expect(metrics.calls_received_get_information).to eq(10000)
     expect(metrics.calls_received_chase_progress).to eq(9000)
     expect(metrics.calls_received_challenge_decision).to eq(8000)

--- a/spec/models/monthly_service_metrics_publish_token_spec.rb
+++ b/spec/models/monthly_service_metrics_publish_token_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe MonthlyServiceMetricsPublishToken, type: :model do
+  describe '.valid?' do
+    let(:month) { instance_double(YearMonth) }
+    let(:service) { instance_double(Service, publish_token: 'ea8546acb283f48c8bf051f8b3fffa76de789523b6ffc4cae5944283e7768d5259b6daf8a770ce0f359b190963eea6ad5fefaeabc7e51bbfadc1753aa29334ee') }
+    let(:metrics) { instance_double(MonthlyServiceMetrics, month: month, service: service) }
+
+    it 'raises ArgumentError when MonthlyServiceMetrics#service not set' do
+      expect {
+        allow(metrics).to receive(:service) { nil }
+        MonthlyServiceMetricsPublishToken.valid?(token: 'token', metrics: metrics)
+      }.to raise_error(ArgumentError, 'MonthlyServiceMetrics#service must be set')
+    end
+
+    it 'raises ArgumentError when MonthlyServiceMetrics#month not set' do
+      expect {
+        allow(metrics).to receive(:month) { nil }
+        MonthlyServiceMetricsPublishToken.valid?(token: 'token', metrics: metrics)
+      }.to raise_error(ArgumentError, 'MonthlyServiceMetrics#month must be set')
+    end
+
+    it 'is falsey when token not set' do
+      expect(MonthlyServiceMetricsPublishToken.valid?(token: nil, metrics: metrics)).to be_falsey
+    end
+
+    it 'is truthy with a valid token' do
+      allow(month).to receive_messages(year: 2017, month: 6)
+      token = MonthlyServiceMetricsPublishToken.generate(service: service, month: month)
+      expect(MonthlyServiceMetricsPublishToken.valid?(token: token, metrics: metrics)).to be_truthy
+    end
+
+    it 'is falsey with an invalid token' do
+      token = 'junk'
+      expect(MonthlyServiceMetricsPublishToken.valid?(token: token, metrics: metrics)).to be_falsey
+    end
+
+    it 'is falsey with a token for another month' do
+      allow(month).to receive_messages(year: 2017, month: 6)
+
+      token = MonthlyServiceMetricsPublishToken.generate(service: service, month: instance_double(YearMonth, year: 2017, month: 12))
+      expect(MonthlyServiceMetricsPublishToken.valid?(token: token, metrics: metrics)).to be_falsey
+    end
+  end
+
+  describe '.generate' do
+    let(:month) { instance_double(YearMonth, year: 2017, month: 6) }
+    let(:service) { instance_double(Service, publish_token: 'ea8546acb283f48c8bf051f8b3fffa76de789523b6ffc4cae5944283e7768d5259b6daf8a770ce0f359b190963eea6ad5fefaeabc7e51bbfadc1753aa29334ee') }
+
+    it 'returns a token, encoding the month & year' do
+      token = MonthlyServiceMetricsPublishToken.generate(service: service, month: month)
+
+      verifier = ActiveSupport::MessageVerifier.new(service.publish_token)
+      payload = verifier.verify(token)
+      expect(payload[:year]).to eq(2017)
+      expect(payload[:month]).to eq(6)
+    end
+  end
+end

--- a/spec/models/monthly_service_metrics_spec.rb
+++ b/spec/models/monthly_service_metrics_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe MonthlyServiceMetrics, type: :model do
+  describe '#publish_date' do
+    it "returns nil if there's no month" do
+      metrics = FactoryGirl.build(:monthly_service_metrics, month: nil)
+      expect(metrics.publish_date).to be_nil
+    end
+
+    it 'returns the first of the month, 2 months from the given month' do
+      metrics = FactoryGirl.build(:monthly_service_metrics, month: YearMonth.new(2017, 11))
+      expect(metrics.publish_date).to eq(Date.new(2018, 1, 1))
+    end
+  end
+
+  describe '#next_metrics_due_date' do
+    it "returns nil if there's no month" do
+      metrics = FactoryGirl.build(:monthly_service_metrics, month: nil)
+      expect(metrics.next_metrics_due_date).to be_nil
+    end
+
+    it 'returns the first of the month, 2 months from the given month' do
+      metrics = FactoryGirl.build(:monthly_service_metrics, month: YearMonth.new(2017, 11))
+      expect(metrics.next_metrics_due_date).to eq(Date.new(2017, 12, 1))
+    end
+  end
+end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -13,4 +13,13 @@ RSpec.describe Service, type: :model do
       expect(service).to_not be_valid
     end
   end
+
+  it 'generates a publish token, when created' do
+    service = FactoryGirl.build(:service)
+    expect {
+      service.save
+    }.to change(service, :publish_token)
+
+    expect(service.publish_token.size).to eq(128)
+  end
 end

--- a/spec/models/year_month_spec.rb
+++ b/spec/models/year_month_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe YearMonth, type: :model do
+  describe '#initialize' do
+    it 'can be initialized with Numeric arguments' do
+      month = YearMonth.new(2017, 9)
+      expect(month.year).to eq(2017)
+      expect(month.month).to eq(9)
+    end
+
+    it 'can be initialized with String arguments' do
+      month = YearMonth.new('2017', '09')
+      expect(month.year).to eq(2017)
+      expect(month.month).to eq(9)
+    end
+
+    it "raises ArgumentError if it's invalid" do
+      expect { YearMonth.new(nil, nil) }.to raise_error(ArgumentError)
+      expect { YearMonth.new(2017, 0) }.to raise_error(ArgumentError)
+      expect { YearMonth.new(2017, 13) }.to raise_error(ArgumentError)
+    end
+  end
+
+  specify 'equality' do
+    expect(YearMonth.new(2017, 9)).to eq(YearMonth.new(2017, 9))
+    expect(YearMonth.new(2017, 8)).to_not eq(YearMonth.new(2017, 9))
+    expect(YearMonth.new(2017, 9)).to_not eq(YearMonth.new(2017, 8))
+  end
+
+  specify '#to_formatted_s' do
+    month = YearMonth.new(2017, 9)
+    expect(month.to_formatted_s).to eq('1 to 30 September 2017')
+  end
+end

--- a/spec/routing/monthly_service_metrics_routing_spec.rb
+++ b/spec/routing/monthly_service_metrics_routing_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe 'monthly service metrics routing', type: :routing do
+
+  specify 'GET MonthlyServiceMetrics#edit' do
+    expect({ get: '/services/001/metrics/2017/09' }).to route_to(
+      controller: 'monthly_service_metrics',
+      action: 'edit',
+      service_id: '001',
+      year: '2017',
+      month: '09',
+    )
+  end
+
+  specify 'PATCH MonthlyServiceMetrics#edit' do
+    expect({ patch: '/services/001/metrics/2017/09' }).to route_to(
+      controller: 'monthly_service_metrics',
+      action: 'update',
+      service_id: '001',
+      year: '2017',
+      month: '09',
+    )
+  end
+
+end

--- a/spec/routing/monthly_service_metrics_routing_spec.rb
+++ b/spec/routing/monthly_service_metrics_routing_spec.rb
@@ -1,9 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe 'monthly service metrics routing', type: :routing do
-
   specify 'GET MonthlyServiceMetrics#edit' do
-    expect({ get: '/services/001/metrics/2017/09' }).to route_to(
+    expect(get: '/services/001/metrics/2017/09').to route_to(
       controller: 'monthly_service_metrics',
       action: 'edit',
       service_id: '001',
@@ -13,7 +12,7 @@ RSpec.describe 'monthly service metrics routing', type: :routing do
   end
 
   specify 'PATCH MonthlyServiceMetrics#edit' do
-    expect({ patch: '/services/001/metrics/2017/09' }).to route_to(
+    expect(patch: '/services/001/metrics/2017/09').to route_to(
       controller: 'monthly_service_metrics',
       action: 'update',
       service_id: '001',
@@ -21,5 +20,4 @@ RSpec.describe 'monthly service metrics routing', type: :routing do
       month: '09',
     )
   end
-
 end


### PR DESCRIPTION
Adds a form to allow submission of monthly metrics, per service. It protects the submission using a token which is valid for a given service, on a given month.

If the URL is re-visited, and the form re-submitted, then the metrics for that month are updated.

There's a script to generate all the paths, with their tokens, for all services for the specified month.